### PR TITLE
Стилизация кастомного чекбокса и формы

### DIFF
--- a/custom-checkbox-styles-complete.css
+++ b/custom-checkbox-styles-complete.css
@@ -1,0 +1,137 @@
+selector svg{
+    width: 25px;
+}
+
+/* Скрываем нативный чекбокс */
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  pointer-events: none;
+}
+
+/* Контейнер для правильного выравнивания */
+.elementor-field-group-acceptance2 .elementor-field-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+/* Стили для label с текстом */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"] {
+  position: relative;
+  padding-left: 24px;
+  cursor: pointer;
+  line-height: 1.4;
+  color: #011C2B;
+  display: block;
+  font-size: 14px !important;
+}
+
+/* Кастомный чекбокс - unchecked состояние */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border: 0.5px solid #011C2B;
+  border-radius: 3px;
+  background: transparent;
+  transition: border-width 0.2s ease;
+  box-sizing: border-box;
+}
+
+/* Галочка - цвет #011C2B */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0px;
+  width: 14px;
+  height: 12px;
+  background-image: url('data:image/svg+xml;utf8,<svg width="14" height="12" viewBox="0 0 14 12" xmlns="http://www.w3.org/2000/svg"><path d="M0.791504 8.41667L4.62484 11.2917L13.2498 0.75" stroke="%23011C2B" stroke-width="0.8" fill="none"/></svg>');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+/* Checked состояние - утолщаем рамку и показываем галочку */
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:checked + label::before {
+  border-width: 0.8px;
+}
+
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:checked + label::after {
+  opacity: 1;
+}
+
+/* Hover эффект */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]:hover::before {
+  border-color: #011C2B;
+}
+
+/* Disabled состояние */
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:disabled + label {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Стили для ссылки */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"] a {
+  color: #011C2B !important;
+  text-decoration: underline;
+}
+
+selector .elementor-field-subgroup {
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 15px;
+}
+
+selector .elementor-field-group.elementor-column.elementor-field-type-submit.elementor-col-100.e-form__buttons {
+    padding-top: 10px;
+}
+
+selector ::placeholder{
+    opacity: 1;
+}
+
+@media(max-width:1024px) and (min-width:767px){
+   selector .elementor-field-textual.elementor-size-lg{
+        min-height: 50px !important;
+    }
+    
+    selector .elementor-field-subgroup {
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 0px;
+}
+
+selector .elementor-field-group.elementor-column.elementor-field-type-submit.elementor-col-100.e-form__buttons {
+    padding-top: 0px;
+}
+
+.elementor-44 .elementor-element.elementor-element-e112767 .elementor-field-group{
+    margin-bottom: 10px;
+}
+
+.elementor-44 .elementor-element.elementor-element-e112767 .elementor-button{
+    padding: 15px 0px;
+    width: 100%;
+}
+}
+
+@media(max-width:767px){
+  .elementor-44 .elementor-element.elementor-element-e112767 .elementor-button{
+    padding: 15px 0px;
+    width: 100%;
+}
+ .elementor-field-textual.elementor-size-lg{
+        min-height: 52px !important;
+    }
+}

--- a/custom-checkbox-styles.css
+++ b/custom-checkbox-styles.css
@@ -1,0 +1,110 @@
+selector svg{
+    width: 25px;
+}
+
+/* Кастомный чекбокс - unchecked состояние */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border: 0.5px solid #fff;
+  border-radius: 3px;
+  background: transparent;
+  transition: border-width 0.2s ease;
+  box-sizing: border-box;
+}
+
+/* Галочка - цвет #011C2B */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0px;
+  width: 14px;
+  height: 12px;
+  background-image: url('data:image/svg+xml;utf8,<svg width="14" height="12" viewBox="0 0 14 12" xmlns="http://www.w3.org/2000/svg"><path d="M0.791504 8.41667L4.62484 11.2917L13.2498 0.75" stroke="%23fff" stroke-width="0.8" fill="none"/></svg>');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+/* Checked состояние - утолщаем рамку и показываем галочку */
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:checked + label::before {
+  border-width: 0.8px;
+}
+
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:checked + label::after {
+  opacity: 1;
+}
+
+/* Hover эффект */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"]:hover::before {
+  border-color: #011C2B;
+}
+
+/* Disabled состояние */
+.elementor-field-group-acceptance2 input[type="checkbox"].elementor-acceptance-field:disabled + label {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Стили для ссылки */
+.elementor-field-group-acceptance2 label[for="form-field-acceptance2"] a {
+  color: #fff !important;
+  text-decoration: underline;
+}
+
+.elementor-field-subgroup {
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 15px;
+    width: 100%;
+}
+
+.elementor-field-group.elementor-column.elementor-field-type-submit.elementor-col-100.e-form__buttons {
+    padding-top: 10px;
+}
+
+selector ::placeholder{
+    opacity: 1;
+}
+
+@media(max-width:1024px) and (min-width:767px){
+   selector .elementor-field-textual.elementor-size-lg{
+        min-height: 50px !important;
+    }
+    
+    selector .elementor-field-subgroup {
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 0px;
+}
+
+selector .elementor-field-group.elementor-column.elementor-field-type-submit.elementor-col-100.e-form__buttons {
+    padding-top: 0px;
+}
+
+.elementor-44 .elementor-element.elementor-element-e112767 .elementor-field-group{
+    margin-bottom: 10px;
+}
+
+.elementor-494 .elementor-element.elementor-element-ad96655 .elementor-button{
+    padding: 12px 0px;
+    width: 100%;
+}
+}
+
+@media(max-width:767px){
+  .elementor-494 .elementor-element.elementor-element-ad96655 .elementor-button{
+    padding: 12px 0px;
+    width: 100%;
+}
+ .elementor-field-textual.elementor-size-lg{
+        min-height: 52px !important;
+    }
+}

--- a/elementor-custom-query.php
+++ b/elementor-custom-query.php
@@ -94,3 +94,24 @@ add_action('elementor/query/tip_rabot_grid', function (WP_Query $query): void {
 
     $query->set('ignore_sticky_posts', true);
 });
+
+/**
+ * Minimal custom Query ID that preserves widget filters: `tip_rabot`
+ * Use this when Source/filters are already set in the widget.
+ */
+add_action('elementor/query/tip_rabot', function (WP_Query $query): void {
+    // Do not change tax_query or meta_query — respect widget settings
+
+    // Ensure stable ordering only if not specified in the widget
+    if (!$query->get('orderby')) {
+        $query->set('orderby', 'date');
+    }
+    if (!$query->get('order')) {
+        $query->set('order', 'DESC');
+    }
+
+    // Avoid sticky posts affecting results
+    $query->set('ignore_sticky_posts', true);
+
+    // Important: do NOT set offset or no_found_rows here to keep Load More working
+});

--- a/elementor-custom-query.php
+++ b/elementor-custom-query.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Elementor Custom Queries for taxonomy `tip-rabot`.
+ *
+ * How to use in Elementor:
+ * - In Loop Grid: set Query ID to `tip_rabot_grid`
+ * - In Loop Carousel: set Query ID to `tip_rabot_carousel`
+ *
+ * Optional URL params:
+ * - tip-rabot: term slug of taxonomy `tip-rabot` (e.g., ?tip-rabot=remont)
+ * - carousel_count: integer; grid will offset by this to avoid duplicates (e.g., ?carousel_count=5)
+ * - grid_offset: integer; overrides computed offset for grid if provided
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Helper: build tax_query for `tip-rabot` taxonomy from GET param.
+ */
+function er_build_tip_rabot_tax_query_from_request(): array {
+    $term_slug = isset($_GET['tip-rabot']) ? sanitize_text_field(wp_unslash($_GET['tip-rabot'])) : '';
+    if ($term_slug === '' || $term_slug === 'all') {
+        return [];
+    }
+
+    return [
+        [
+            'taxonomy' => 'tip-rabot',
+            'field'    => 'slug',
+            'terms'    => [$term_slug],
+            'operator' => 'IN',
+            'include_children' => true,
+        ],
+    ];
+}
+
+/**
+ * Loop Carousel query: `tip_rabot_carousel`
+ * Use URL: ?tip-rabot=slug to filter by taxonomy term.
+ */
+add_action('elementor/query/tip_rabot_carousel', function (WP_Query $query): void {
+    // Filter by taxonomy if provided
+    $tax_query = er_build_tip_rabot_tax_query_from_request();
+    if (!empty($tax_query)) {
+        $query->set('tax_query', $tax_query);
+    }
+
+    // Stable ordering for predictable offsets/duplicates handling
+    if (!$query->get('orderby')) {
+        $query->set('orderby', 'date');
+    }
+    if (!$query->get('order')) {
+        $query->set('order', 'DESC');
+    }
+
+    // Avoid performance overhead for carousels
+    $query->set('no_found_rows', true);
+    $query->set('ignore_sticky_posts', true);
+});
+
+/**
+ * Loop Grid query: `tip_rabot_grid`
+ * Will auto-apply `offset` based on `carousel_count` URL param to avoid duplicates
+ * with the carousel when both use the same ordering and filters.
+ */
+add_action('elementor/query/tip_rabot_grid', function (WP_Query $query): void {
+    // Filter by taxonomy if provided
+    $tax_query = er_build_tip_rabot_tax_query_from_request();
+    if (!empty($tax_query)) {
+        $query->set('tax_query', $tax_query);
+    }
+
+    // Stable ordering
+    if (!$query->get('orderby')) {
+        $query->set('orderby', 'date');
+    }
+    if (!$query->get('order')) {
+        $query->set('order', 'DESC');
+    }
+
+    // Respect explicit grid_offset if provided
+    $explicit_offset = isset($_GET['grid_offset']) ? intval($_GET['grid_offset']) : null;
+    if ($explicit_offset !== null && $explicit_offset > 0) {
+        $query->set('offset', $explicit_offset);
+    } else {
+        // Compute offset from carousel_count if present
+        $carousel_count = isset($_GET['carousel_count']) ? max(0, intval($_GET['carousel_count'])) : 0;
+        if ($carousel_count > 0) {
+            $query->set('offset', $carousel_count);
+        }
+    }
+
+    $query->set('ignore_sticky_posts', true);
+});


### PR DESCRIPTION
Adapt custom checkbox CSS to match the provided HTML structure.

The original CSS used `field_acceptance2` in its selectors, which was updated to `acceptance2` to correctly target the new HTML element.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc2ce1d8-00dc-4fb0-9d3b-92f7e88526a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc2ce1d8-00dc-4fb0-9d3b-92f7e88526a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

