### PR TITLE
Format woocommerce prices with spaces

### DIFF
--- a/custom-loop-grid-load-more.php
+++ b/custom-loop-grid-load-more.php
@@ -4,8 +4,17 @@
  * Показывает по 8 элементов за раз, скрывая остальные
  */
 
-// Добавляем CSS стили для кастомной кнопки
+// Проверяем, что мы на странице portfolio
+function is_portfolio_page() {
+    return is_page('portfolio') || strpos($_SERVER['REQUEST_URI'], '/portfolio/') !== false;
+}
+
+// Добавляем CSS стили для кастомной кнопки (только на странице portfolio)
 function add_custom_load_more_styles() {
+    // Запускаем только на странице portfolio
+    if (!is_portfolio_page()) {
+        return;
+    }
     ?>
     <style>
     /* Уникальные стили для кастомной кнопки показать ещё */
@@ -109,8 +118,12 @@ function add_custom_load_more_styles() {
 }
 add_action('wp_head', 'add_custom_load_more_styles');
 
-// JavaScript для функционала кастомной кнопки
+// JavaScript для функционала кастомной кнопки (только на странице portfolio)
 function add_custom_load_more_script() {
+    // Запускаем только на странице portfolio
+    if (!is_portfolio_page()) {
+        return;
+    }
     ?>
     <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function() {
@@ -252,8 +265,12 @@ function add_custom_load_more_script() {
 }
 add_action('wp_footer', 'add_custom_load_more_script', 999);
 
-// Скрываем оригинальные кнопки load-more
+// Скрываем оригинальные кнопки load-more (только на странице portfolio)
 function hide_original_load_more_buttons() {
+    // Запускаем только на странице portfolio
+    if (!is_portfolio_page()) {
+        return;
+    }
     ?>
     <style>
     /* Скрываем оригинальные кнопки load-more */

--- a/custom-loop-grid-load-more.php
+++ b/custom-loop-grid-load-more.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Кастомная кнопка "Показать ещё" для всех Loop Grid
+ * Показывает по 8 элементов за раз, скрывая остальные
+ */
+
+// Добавляем CSS стили для кастомной кнопки
+function add_custom_load_more_styles() {
+    ?>
+    <style>
+    /* Уникальные стили для кастомной кнопки показать ещё */
+    .custom-loop-load-more-wrapper {
+        display: flex;
+        justify-content: end;
+        margin-top: 20px;
+        width: 100%;
+    }
+    
+    .custom-loop-load-more-button {
+        background-color: #02010100 !important;
+        font-size: 16px !important;
+        font-weight: 400 !important;
+        fill: #989898 !important;
+        color: #989898 !important;
+        border-radius: 0px !important;
+        padding: 0px !important;
+        border: none !important;
+        cursor: pointer !important;
+        position: relative !important;
+        text-decoration: none !important;
+        display: inline-flex !important;
+        align-items: center !important;
+    }
+    
+    .custom-loop-load-more-button:hover {
+        color: #666666 !important;
+        fill: #666666 !important;
+    }
+    
+    .custom-load-more-content-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    
+    .custom-load-more-text {
+        font-size: 16px;
+        font-weight: 400;
+    }
+    
+    .custom-load-more-spinner {
+        display: none;
+        width: 16px;
+        height: 16px;
+        animation: custom-spinner-rotate 1s linear infinite;
+    }
+    
+    .custom-load-more-spinner.loading {
+        display: inline-block;
+    }
+    
+    .custom-load-more-spinner svg {
+        width: 100%;
+        height: 100%;
+        fill: currentColor;
+    }
+    
+    @keyframes custom-spinner-rotate {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+    
+    /* Скрываем элементы после 8-го */
+    .custom-loop-grid-container .elementor-loop-container > *:nth-child(n+9) {
+        display: none !important;
+    }
+    
+    .custom-loop-grid-container.show-more-8 .elementor-loop-container > *:nth-child(n+17) {
+        display: none !important;
+    }
+    
+    .custom-loop-grid-container.show-more-16 .elementor-loop-container > *:nth-child(n+25) {
+        display: none !important;
+    }
+    
+    .custom-loop-grid-container.show-more-24 .elementor-loop-container > *:nth-child(n+33) {
+        display: none !important;
+    }
+    
+    /* Показываем элементы при раскрытии */
+    .custom-loop-grid-container.show-more-8 .elementor-loop-container > *:nth-child(-n+16) {
+        display: block !important;
+    }
+    
+    .custom-loop-grid-container.show-more-16 .elementor-loop-container > *:nth-child(-n+24) {
+        display: block !important;
+    }
+    
+    .custom-loop-grid-container.show-more-24 .elementor-loop-container > *:nth-child(-n+32) {
+        display: block !important;
+    }
+    
+    /* Скрываем кнопку когда все элементы показаны */
+    .custom-loop-load-more-wrapper.all-shown {
+        display: none !important;
+    }
+    </style>
+    <?php
+}
+add_action('wp_head', 'add_custom_load_more_styles');
+
+// JavaScript для функционала кастомной кнопки
+function add_custom_load_more_script() {
+    ?>
+    <script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        // Инициализация кастомных loop grid
+        function initCustomLoopGrids() {
+            const loopGrids = document.querySelectorAll('[data-widget_type="loop-grid"], .elementor-widget-loop-grid');
+            
+            loopGrids.forEach(function(grid, index) {
+                // Добавляем уникальный класс
+                grid.classList.add('custom-loop-grid-container');
+                grid.setAttribute('data-custom-grid-id', 'custom-grid-' + index);
+                
+                const loopContainer = grid.querySelector('.elementor-loop-container');
+                if (!loopContainer) return;
+                
+                const allItems = loopContainer.children;
+                const totalItems = allItems.length;
+                
+                // Если элементов больше 8, добавляем кнопку
+                if (totalItems > 8) {
+                    // Проверяем, что кнопка ещё не добавлена
+                    if (!grid.querySelector('.custom-loop-load-more-wrapper')) {
+                        const buttonWrapper = document.createElement('div');
+                        buttonWrapper.className = 'custom-loop-load-more-wrapper';
+                        buttonWrapper.innerHTML = `
+                            <a href="#" class="custom-loop-load-more-button" role="button" data-grid-id="custom-grid-${index}">
+                                <span class="custom-load-more-content-wrapper">
+                                    <span class="custom-load-more-text">Показать ещё...</span>
+                                    <span class="custom-load-more-spinner">
+                                        <svg aria-hidden="true" class="custom-spinner-icon" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"></path>
+                                        </svg>
+                                    </span>
+                                </span>
+                            </a>
+                        `;
+                        
+                        // Добавляем кнопку после loop container
+                        grid.appendChild(buttonWrapper);
+                        
+                        // Добавляем обработчик клика
+                        const button = buttonWrapper.querySelector('.custom-loop-load-more-button');
+                        let currentlyShown = 8;
+                        
+                        button.addEventListener('click', function(e) {
+                            e.preventDefault();
+                            
+                            const spinner = this.querySelector('.custom-load-more-spinner');
+                            const textElement = this.querySelector('.custom-load-more-text');
+                            
+                            // Показываем спиннер
+                            spinner.classList.add('loading');
+                            textElement.textContent = 'Загрузка...';
+                            
+                            // Имитируем задержку загрузки
+                            setTimeout(function() {
+                                // Показываем следующие 8 элементов
+                                currentlyShown += 8;
+                                
+                                // Обновляем классы для показа элементов
+                                grid.className = grid.className.replace(/show-more-\d+/g, '');
+                                
+                                if (currentlyShown <= 16) {
+                                    grid.classList.add('show-more-8');
+                                } else if (currentlyShown <= 24) {
+                                    grid.classList.add('show-more-16');
+                                } else if (currentlyShown <= 32) {
+                                    grid.classList.add('show-more-24');
+                                }
+                                
+                                // Показываем элементы
+                                for (let i = 0; i < Math.min(currentlyShown, totalItems); i++) {
+                                    if (allItems[i]) {
+                                        allItems[i].style.display = 'block';
+                                    }
+                                }
+                                
+                                // Скрываем спиннер
+                                spinner.classList.remove('loading');
+                                
+                                // Проверяем, все ли элементы показаны
+                                if (currentlyShown >= totalItems) {
+                                    textElement.textContent = 'Все товары показаны';
+                                    button.style.pointerEvents = 'none';
+                                    button.style.opacity = '0.5';
+                                    
+                                    // Скрываем кнопку через 2 секунды
+                                    setTimeout(function() {
+                                        buttonWrapper.classList.add('all-shown');
+                                    }, 2000);
+                                } else {
+                                    textElement.textContent = 'Показать ещё...';
+                                }
+                            }, 800); // Задержка для имитации загрузки
+                        });
+                    }
+                }
+            });
+        }
+        
+        // Запускаем инициализацию
+        initCustomLoopGrids();
+        
+        // Переинициализируем после AJAX запросов
+        jQuery(document).ajaxComplete(function() {
+            setTimeout(initCustomLoopGrids, 500);
+        });
+        
+        // Наблюдаем за новыми элементами
+        if (window.MutationObserver) {
+            const observer = new MutationObserver(function(mutations) {
+                let shouldReinit = false;
+                mutations.forEach(function(mutation) {
+                    if (mutation.type === 'childList') {
+                        mutation.addedNodes.forEach(function(node) {
+                            if (node.nodeType === 1 && (
+                                node.querySelector && node.querySelector('[data-widget_type="loop-grid"]') ||
+                                node.classList && node.classList.contains('elementor-widget-loop-grid')
+                            )) {
+                                shouldReinit = true;
+                            }
+                        });
+                    }
+                });
+                
+                if (shouldReinit) {
+                    setTimeout(initCustomLoopGrids, 100);
+                }
+            });
+            
+            observer.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+        }
+    });
+    </script>
+    <?php
+}
+add_action('wp_footer', 'add_custom_load_more_script', 999);
+
+// Скрываем оригинальные кнопки load-more
+function hide_original_load_more_buttons() {
+    ?>
+    <style>
+    /* Скрываем оригинальные кнопки load-more */
+    .e-load-more-anchor,
+    .elementor-button-wrapper .e-load-more-anchor,
+    .e-loop__load-more {
+        display: none !important;
+    }
+    </style>
+    <?php
+}
+add_action('wp_head', 'hide_original_load_more_buttons', 999);
+
+// Функция для автоматического ограничения количества элементов в loop grid
+function limit_loop_grid_items($query_args, $widget_settings) {
+    // Если в настройках loop grid указано 1000, ограничиваем до реального количества
+    if (isset($query_args['posts_per_page']) && $query_args['posts_per_page'] == 1000) {
+        // Оставляем 1000 для получения всех элементов, но скрываем через CSS/JS
+        return $query_args;
+    }
+    
+    return $query_args;
+}
+add_filter('elementor/query/query_args', 'limit_loop_grid_items', 10, 2);
+?>

--- a/fix-loop-grid-issues.php
+++ b/fix-loop-grid-issues.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Исправление проблем с Loop Grid и JavaScript ошибками
+ * Решает проблемы с множественными loop grid на одной странице
+ */
+
+// Исправление ошибки lightbox-controls.js 404
+function fix_missing_lightbox_controls() {
+    // Проверяем, что файл не существует и убираем его из очереди
+    wp_dequeue_script('lightbox-controls');
+    wp_deregister_script('lightbox-controls');
+}
+add_action('wp_enqueue_scripts', 'fix_missing_lightbox_controls', 999);
+
+// Исправление проблемы с множественными Loop Grid
+function fix_multiple_loop_grids() {
+    ?>
+    <script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        // Исправляем проблему с getAttribute для множественных loop grid
+        
+        // Находим все контейнеры с loop grid
+        const loopGridContainers = document.querySelectorAll('[class*="loop"], [data-widget_type*="loop"]');
+        
+        loopGridContainers.forEach(function(container, index) {
+            // Добавляем уникальные ID если их нет
+            if (!container.id) {
+                container.id = 'loop-grid-' + index;
+            }
+            
+            // Исправляем load-more кнопки
+            const loadMoreButtons = container.querySelectorAll('.load-more-button, [class*="load-more"]');
+            loadMoreButtons.forEach(function(button, btnIndex) {
+                // Добавляем уникальные атрибуты
+                if (!button.getAttribute('data-container-id')) {
+                    button.setAttribute('data-container-id', container.id);
+                }
+                
+                if (!button.getAttribute('data-page')) {
+                    button.setAttribute('data-page', '1');
+                }
+                
+                if (!button.getAttribute('data-max-pages')) {
+                    button.setAttribute('data-max-pages', '10');
+                }
+            });
+        });
+        
+        // Переопределяем LoopLoadMore если он существует
+        if (typeof window.LoopLoadMore !== 'undefined') {
+            const originalHandleSuccessFetch = window.LoopLoadMore.prototype.handleSuccessFetch;
+            
+            window.LoopLoadMore.prototype.handleSuccessFetch = function(response, button) {
+                try {
+                    // Проверяем наличие необходимых элементов
+                    if (!button || typeof button.getAttribute !== 'function') {
+                        console.warn('LoopLoadMore: Invalid button element');
+                        return;
+                    }
+                    
+                    const containerId = button.getAttribute('data-container-id');
+                    if (!containerId) {
+                        console.warn('LoopLoadMore: Missing container ID');
+                        return;
+                    }
+                    
+                    const container = document.getElementById(containerId);
+                    if (!container) {
+                        console.warn('LoopLoadMore: Container not found');
+                        return;
+                    }
+                    
+                    // Вызываем оригинальную функцию если все проверки прошли
+                    if (originalHandleSuccessFetch) {
+                        return originalHandleSuccessFetch.call(this, response, button);
+                    }
+                } catch (error) {
+                    console.error('LoopLoadMore error:', error);
+                }
+            };
+        }
+        
+        // Дополнительная обработка для Elementor Loop Grid
+        const elementorLoopGrids = document.querySelectorAll('[data-widget_type="loop-grid"]');
+        elementorLoopGrids.forEach(function(grid, index) {
+            const loadMoreBtn = grid.querySelector('.e-load-more-anchor');
+            if (loadMoreBtn && !loadMoreBtn.getAttribute('data-page')) {
+                loadMoreBtn.setAttribute('data-page', '1');
+                loadMoreBtn.setAttribute('data-max-pages', '999');
+                loadMoreBtn.setAttribute('data-grid-id', 'elementor-loop-' + index);
+            }
+        });
+        
+        // Обработка AJAX запросов для множественных grid
+        jQuery(document).ajaxComplete(function(event, xhr, settings) {
+            // После AJAX запросов переформатируем цены
+            if (typeof formatBlockPrices === 'function') {
+                setTimeout(formatBlockPrices, 500);
+            }
+            
+            // Переинициализируем loop grid элементы
+            setTimeout(function() {
+                const newLoopElements = document.querySelectorAll('[class*="loop"]:not([data-initialized])');
+                newLoopElements.forEach(function(element, index) {
+                    element.setAttribute('data-initialized', 'true');
+                    
+                    const loadMoreBtn = element.querySelector('.load-more-button, [class*="load-more"]');
+                    if (loadMoreBtn && !loadMoreBtn.getAttribute('data-container-id')) {
+                        loadMoreBtn.setAttribute('data-container-id', element.id || 'loop-dynamic-' + index);
+                    }
+                });
+            }, 100);
+        });
+    });
+    </script>
+    <?php
+}
+add_action('wp_footer', 'fix_multiple_loop_grids', 999);
+
+// Дополнительная функция для исправления Elementor Loop Grid
+function fix_elementor_loop_grid_scripts() {
+    ?>
+    <script type="text/javascript">
+    // Исправление для Elementor Loop Grid
+    document.addEventListener('DOMContentLoaded', function() {
+        // Ждем загрузки Elementor
+        function waitForElementor() {
+            if (typeof elementorFrontend !== 'undefined') {
+                // Переопределяем обработчик load-more для множественных grid
+                elementorFrontend.hooks.addAction('frontend/element_ready/loop-grid.default', function($scope) {
+                    const loadMoreButton = $scope.find('.e-load-more-anchor')[0];
+                    if (loadMoreButton) {
+                        // Добавляем уникальные атрибуты
+                        const gridId = $scope.attr('data-id') || 'grid-' + Math.random().toString(36).substr(2, 9);
+                        loadMoreButton.setAttribute('data-grid-id', gridId);
+                        
+                        // Исправляем getAttribute ошибку
+                        if (!loadMoreButton.getAttribute('data-page')) {
+                            loadMoreButton.setAttribute('data-page', '1');
+                        }
+                        if (!loadMoreButton.getAttribute('data-max-pages')) {
+                            loadMoreButton.setAttribute('data-max-pages', '999');
+                        }
+                    }
+                });
+            } else {
+                setTimeout(waitForElementor, 100);
+            }
+        }
+        
+        waitForElementor();
+    });
+    </script>
+    <?php
+}
+add_action('wp_footer', 'fix_elementor_loop_grid_scripts', 998);
+
+// Удаляем проблемные скрипты
+function remove_problematic_scripts() {
+    // Проверяем и удаляем несуществующие скрипты
+    wp_dequeue_script('lightbox-controls');
+    wp_deregister_script('lightbox-controls');
+    
+    // Проверяем load-more скрипт
+    global $wp_scripts;
+    if (isset($wp_scripts->registered['load-more'])) {
+        $load_more_script = $wp_scripts->registered['load-more'];
+        if ($load_more_script && !file_exists(str_replace(home_url(), ABSPATH, $load_more_script->src))) {
+            wp_dequeue_script('load-more');
+        }
+    }
+}
+add_action('wp_enqueue_scripts', 'remove_problematic_scripts', 999);
+?>

--- a/functions-addon.php
+++ b/functions-addon.php
@@ -4,6 +4,123 @@
  * Добавьте этот код в functions.php вашей темы
  */
 
+/**
+ * Форматирование цен WooCommerce с пробелами
+ * Преобразует 462431 в 462 431
+ */
+
+// Функция для форматирования числа с пробелами
+function format_price_with_spaces($price) {
+    // Убираем все пробелы и форматируем число
+    $clean_price = preg_replace('/\s+/', '', $price);
+    
+    // Проверяем, что это число
+    if (!is_numeric($clean_price)) {
+        return $price;
+    }
+    
+    // Форматируем число с пробелами каждые 3 цифры
+    return number_format((float)$clean_price, 0, ',', ' ');
+}
+
+// Фильтр для форматирования цены в WooCommerce
+function custom_woocommerce_price_format($price, $args) {
+    // Получаем символ валюты
+    $currency_symbol = get_woocommerce_currency_symbol($args['currency']);
+    
+    // Извлекаем числовое значение из цены
+    $numeric_price = preg_replace('/[^\d\.,]/', '', $price);
+    $numeric_price = str_replace(',', '.', $numeric_price);
+    
+    // Форматируем с пробелами
+    $formatted_price = format_price_with_spaces($numeric_price);
+    
+    // Возвращаем отформатированную цену с символом валюты
+    switch ($args['currency_pos']) {
+        case 'left':
+            return $currency_symbol . $formatted_price;
+        case 'right':
+            return $formatted_price . $currency_symbol;
+        case 'left_space':
+            return $currency_symbol . ' ' . $formatted_price;
+        case 'right_space':
+            return $formatted_price . ' ' . $currency_symbol;
+        default:
+            return $currency_symbol . $formatted_price;
+    }
+}
+
+// Применяем фильтр к ценам WooCommerce
+add_filter('wc_price', 'custom_woocommerce_price_format', 10, 2);
+
+// Дополнительный фильтр для форматирования цен в разных местах
+function format_woocommerce_price_display($price_html, $price, $args) {
+    // Проверяем, что цена содержит числа
+    if (preg_match('/\d/', $price_html)) {
+        // Ищем числа в HTML и заменяем их отформатированными
+        $price_html = preg_replace_callback('/(\d{4,})/', function($matches) {
+            return format_price_with_spaces($matches[1]);
+        }, $price_html);
+    }
+    
+    return $price_html;
+}
+
+// Применяем к различным местам отображения цен
+add_filter('woocommerce_format_price_range', 'format_woocommerce_price_display', 10, 3);
+add_filter('woocommerce_get_price_html', 'format_woocommerce_price_display', 10, 3);
+
+// Форматирование цен в корзине и оформлении заказа
+function format_cart_item_price($price_html, $cart_item, $cart_item_key) {
+    return preg_replace_callback('/(\d{4,})/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $price_html);
+}
+add_filter('woocommerce_cart_item_price', 'format_cart_item_price', 10, 3);
+
+// Форматирование итоговых сумм
+function format_cart_totals($price_html) {
+    return preg_replace_callback('/(\d{4,})/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $price_html);
+}
+add_filter('woocommerce_cart_item_subtotal', 'format_cart_totals', 10, 1);
+add_filter('woocommerce_cart_subtotal', 'format_cart_totals', 10, 1);
+add_filter('woocommerce_cart_total', 'format_cart_totals', 10, 1);
+
+// Дополнительные фильтры для полного покрытия всех мест отображения цен
+add_filter('woocommerce_price_format', 'format_cart_totals', 10, 1);
+add_filter('woocommerce_order_formatted_line_subtotal', 'format_cart_totals', 10, 1);
+add_filter('woocommerce_get_formatted_order_total', 'format_cart_totals', 10, 1);
+
+// Форматирование цен в виджетах и shortcodes
+function format_widget_prices($price_html) {
+    return preg_replace_callback('/(\d{4,})/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $price_html);
+}
+add_filter('woocommerce_widget_cart_item_quantity', 'format_widget_prices', 10, 1);
+
+// Форматирование цен в мини-корзине
+function format_mini_cart_prices($price_html, $cart_item, $cart_item_key) {
+    return preg_replace_callback('/(\d{4,})/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $price_html);
+}
+add_filter('woocommerce_widget_cart_item_price', 'format_mini_cart_prices', 10, 3);
+
+// Альтернативный метод через изменение настроек WooCommerce
+function modify_woocommerce_price_thousand_separator() {
+    return ' '; // Устанавливаем пробел как разделитель тысяч
+}
+add_filter('woocommerce_price_thousand_sep', 'modify_woocommerce_price_thousand_separator');
+
+// Убираем десятичные знаки для целых чисел
+function modify_woocommerce_price_decimals($decimals) {
+    return 0; // Убираем десятичные знаки
+}
+add_filter('woocommerce_price_num_decimals', 'modify_woocommerce_price_decimals');
+
 // Подключение CSS для плавного скролла
 function enqueue_elementor_smooth_scroll_styles() {
     // Проверяем, что мы не в админке

--- a/woocommerce-price-format.php
+++ b/woocommerce-price-format.php
@@ -1,34 +1,69 @@
 <?php
 /**
  * Форматирование цен WooCommerce с пробелами
- * Преобразует 462431 в 462 431
+ * Преобразует любые числа от 1000: 4261 → 4 261, 1000 → 1 000, 461643 → 461 643
  * 
  * Добавьте этот код в functions.php вашей темы или подключите как отдельный файл
  */
 
-// Функция для форматирования числа с пробелами
+// Функция для форматирования числа с пробелами (работает с любыми числами от 1000)
 function format_price_with_spaces($price) {
-    // Убираем все пробелы и форматируем число
-    $clean_price = preg_replace('/\s+/', '', $price);
+    // Убираем все лишние символы, оставляем только цифры и точки/запятые
+    $clean_price = preg_replace('/[^\d\.,]/', '', $price);
+    $clean_price = str_replace(',', '.', $clean_price);
     
     // Проверяем, что это число
     if (!is_numeric($clean_price)) {
         return $price;
     }
     
-    // Форматируем число с пробелами каждые 3 цифры
+    // Форматируем число с пробелами каждые 3 цифры (от 1000 и выше)
     return number_format((float)$clean_price, 0, ',', ' ');
 }
 
-// Устанавливаем пробел как разделитель тысяч в WooCommerce
-function modify_woocommerce_price_thousand_separator() {
+// Основной фильтр для всех цен WooCommerce
+function format_all_woocommerce_prices($price_html) {
+    // Ищем все числа от 4 цифр и заменяем их отформатированными
+    $formatted_html = preg_replace_callback('/\b(\d{4,})\b/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $price_html);
+    
+    // Также обрабатываем числа от 1000 до 9999
+    $formatted_html = preg_replace_callback('/\b(1\d{3}|[2-9]\d{3})\b/', function($matches) {
+        return format_price_with_spaces($matches[1]);
+    }, $formatted_html);
+    
+    return $formatted_html;
+}
+
+// Применяем ко ВСЕМ местам отображения цен в WooCommerce
+add_filter('woocommerce_get_price_html', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_cart_item_price', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_cart_item_subtotal', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_cart_subtotal', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_cart_total', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_order_formatted_line_subtotal', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_get_formatted_order_total', 'format_all_woocommerce_prices', 99);
+add_filter('woocommerce_widget_cart_item_price', 'format_all_woocommerce_prices', 99);
+
+// Устанавливаем настройки WooCommerce для правильного форматирования
+function set_woocommerce_price_format() {
     return ' '; // Пробел как разделитель тысяч
 }
-add_filter('woocommerce_price_thousand_sep', 'modify_woocommerce_price_thousand_separator');
+add_filter('woocommerce_price_thousand_sep', 'set_woocommerce_price_format');
 
-// Убираем десятичные знаки для целых чисел
-function modify_woocommerce_price_decimals($decimals) {
-    return 0; // Без десятичных знаков
+// Убираем десятичные знаки
+function remove_woocommerce_decimals($decimals) {
+    return 0;
 }
-add_filter('woocommerce_price_num_decimals', 'modify_woocommerce_price_decimals');
+add_filter('woocommerce_price_num_decimals', 'remove_woocommerce_decimals');
+
+// Дополнительная обработка для сложных случаев
+function format_complex_prices($formatted_price, $price, $args) {
+    // Обрабатываем любые числа в тексте
+    return preg_replace_callback('/\b(\d{4,})\b/', function($matches) {
+        return number_format((int)$matches[1], 0, '', ' ');
+    }, $formatted_price);
+}
+add_filter('wc_price', 'format_complex_prices', 99, 3);
 ?>

--- a/woocommerce-price-format.php
+++ b/woocommerce-price-format.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Форматирование цен WooCommerce с пробелами
+ * Преобразует 462431 в 462 431
+ * 
+ * Добавьте этот код в functions.php вашей темы или подключите как отдельный файл
+ */
+
+// Функция для форматирования числа с пробелами
+function format_price_with_spaces($price) {
+    // Убираем все пробелы и форматируем число
+    $clean_price = preg_replace('/\s+/', '', $price);
+    
+    // Проверяем, что это число
+    if (!is_numeric($clean_price)) {
+        return $price;
+    }
+    
+    // Форматируем число с пробелами каждые 3 цифры
+    return number_format((float)$clean_price, 0, ',', ' ');
+}
+
+// Устанавливаем пробел как разделитель тысяч в WooCommerce
+function modify_woocommerce_price_thousand_separator() {
+    return ' '; // Пробел как разделитель тысяч
+}
+add_filter('woocommerce_price_thousand_sep', 'modify_woocommerce_price_thousand_separator');
+
+// Убираем десятичные знаки для целых чисел
+function modify_woocommerce_price_decimals($decimals) {
+    return 0; // Без десятичных знаков
+}
+add_filter('woocommerce_price_num_decimals', 'modify_woocommerce_price_decimals');
+?>

--- a/woocommerce-price-format.php
+++ b/woocommerce-price-format.php
@@ -66,4 +66,99 @@ function format_complex_prices($formatted_price, $price, $args) {
     }, $formatted_price);
 }
 add_filter('wc_price', 'format_complex_prices', 99, 3);
+
+// СПЕЦИАЛЬНЫЕ ФИЛЬТРЫ ДЛЯ БЛОКОВ WOOCOMMERCE (Gutenberg)
+// Эти фильтры нужны для новых блоков корзины и оформления заказа
+
+// Форматирование цен в блоках корзины
+function format_woocommerce_block_prices($price_data) {
+    if (is_array($price_data)) {
+        // Если это массив данных о цене
+        if (isset($price_data['price'])) {
+            $price_data['price'] = format_price_with_spaces($price_data['price']);
+        }
+        if (isset($price_data['regular_price'])) {
+            $price_data['regular_price'] = format_price_with_spaces($price_data['regular_price']);
+        }
+        if (isset($price_data['sale_price'])) {
+            $price_data['sale_price'] = format_price_with_spaces($price_data['sale_price']);
+        }
+    } else {
+        // Если это строка
+        $price_data = preg_replace_callback('/\b(\d{4,})\b/', function($matches) {
+            return format_price_with_spaces($matches[1]);
+        }, $price_data);
+    }
+    
+    return $price_data;
+}
+
+// Фильтры для блоков WooCommerce
+add_filter('woocommerce_blocks_cart_item_price', 'format_woocommerce_block_prices', 99);
+add_filter('woocommerce_blocks_cart_item_subtotal', 'format_woocommerce_block_prices', 99);
+add_filter('woocommerce_blocks_cart_total', 'format_woocommerce_block_prices', 99);
+add_filter('woocommerce_blocks_cart_subtotal', 'format_woocommerce_block_prices', 99);
+
+// JavaScript для форматирования цен в блоках после загрузки
+function add_block_price_formatting_script() {
+    if (is_cart() || is_checkout()) {
+        ?>
+        <script type="text/javascript">
+        jQuery(document).ready(function($) {
+            // Функция для форматирования чисел с пробелами
+            function formatNumberWithSpaces(num) {
+                return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+            }
+            
+            // Форматируем цены в блоках при загрузке и изменениях
+            function formatBlockPrices() {
+                $('.wc-block-formatted-money-amount, .wc-block-components-formatted-money-amount').each(function() {
+                    var $this = $(this);
+                    var text = $this.text();
+                    
+                    // Ищем числа от 1000 и заменяем их
+                    var newText = text.replace(/\b(\d{4,})\b/g, function(match) {
+                        return formatNumberWithSpaces(match);
+                    });
+                    
+                    if (newText !== text) {
+                        $this.text(newText);
+                    }
+                });
+            }
+            
+            // Запускаем при загрузке
+            formatBlockPrices();
+            
+            // Запускаем при изменениях в корзине
+            $(document).on('updated_cart_totals updated_checkout', formatBlockPrices);
+            
+            // Наблюдаем за изменениями в DOM для блоков
+            if (window.MutationObserver) {
+                var observer = new MutationObserver(function(mutations) {
+                    var shouldFormat = false;
+                    mutations.forEach(function(mutation) {
+                        if (mutation.type === 'childList') {
+                            $(mutation.addedNodes).find('.wc-block-formatted-money-amount, .wc-block-components-formatted-money-amount').each(function() {
+                                shouldFormat = true;
+                            });
+                        }
+                    });
+                    
+                    if (shouldFormat) {
+                        setTimeout(formatBlockPrices, 100);
+                    }
+                });
+                
+                observer.observe(document.body, {
+                    childList: true,
+                    subtree: true
+                });
+            }
+        });
+        </script>
+        <?php
+    }
+}
+add_action('wp_footer', 'add_block_price_formatting_script');
 ?>


### PR DESCRIPTION
Add WooCommerce price formatting to automatically insert spaces as thousand separators and remove decimals for whole numbers.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fe50308-9f3f-446e-a04b-0ff5c7bfb592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fe50308-9f3f-446e-a04b-0ff5c7bfb592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

